### PR TITLE
User stats page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import NotFound from "./pages/notFound/NotFound";
 import Register from "./pages/register/Register";
 import UpdateUser from "./pages/updateUser/UpdateUser";
 import Users from "./pages/users/Users"
+import UserStats from "./pages/userStats/UserStats";
 
 function App() {
   return (
@@ -41,6 +42,11 @@ function App() {
           exact
           path="/users"
           component={Users}
+        />
+        <Route
+          exact
+          path="/stats/:email"
+          component={UserStats}
         />
         <Route
           exact

--- a/src/components/header/UserNav.js
+++ b/src/components/header/UserNav.js
@@ -31,6 +31,8 @@ function UserNav(props) {
         Welcome, Guest
       </Navbar.Text>
       <Nav.Link as={Link} to="/login" href="/login">Sign in</Nav.Link>
+      {/* Will need to delete this later */}
+      <Nav.Link as={Link} to={`/stats/${props.auth.email}`} href={`/stats/${props.auth.email}`}>Your Stats</Nav.Link>
       <Nav.Link as={Link} to="/register" href="/register">Register</Nav.Link>
     </>
   )

--- a/src/components/header/UserNav.js
+++ b/src/components/header/UserNav.js
@@ -41,6 +41,7 @@ function UserNav(props) {
           Hello, {props.auth.email}
         </Navbar.Text>
         <Nav.Link as={Link} to="/users" href="/users">Registered Users</Nav.Link>
+        <Nav.Link as={Link} to={`/stats/${props.auth.email}`} href={`/stats/${props.auth.email}`}>Your Stats</Nav.Link>
         <Nav.Link as={Link} to={`/updateuser/${props.auth.email}`} href={`/updateuser/${props.auth.email}`}> Edit Profile</Nav.Link>
         <Nav.Link onClick={handleSignOut}>Sign Out</Nav.Link>
       </>

--- a/src/components/header/UserNav.js
+++ b/src/components/header/UserNav.js
@@ -31,8 +31,6 @@ function UserNav(props) {
         Welcome, Guest
       </Navbar.Text>
       <Nav.Link as={Link} to="/login" href="/login">Sign in</Nav.Link>
-      {/* Will need to delete this later */}
-      <Nav.Link as={Link} to={`/stats/${props.auth.email}`} href={`/stats/${props.auth.email}`}>Your Stats</Nav.Link>
       <Nav.Link as={Link} to="/register" href="/register">Register</Nav.Link>
     </>
   )

--- a/src/pages/userStats/UserStats.js
+++ b/src/pages/userStats/UserStats.js
@@ -59,7 +59,7 @@ class UserStats extends Component {
                         <tr>
                             <th>Number of questions answered</th>
                             <th>Correct Answers</th>
-                            <th>Worng Answers</th>
+                            <th>Wrong Answers</th>
                             <th>Win Percentage</th>
                         </tr>
                     </thead>
@@ -68,7 +68,7 @@ class UserStats extends Component {
                             <td>{this.state.userStats.questionsAttempted}</td>
                             <td>{this.state.userStats.correctAnswers}</td>
                             <td>{this.state.userStats.wrongAnswers}</td>
-                            <td></td>
+                            <td>{this.state.userStats.winRatio}</td>
                         </tr>
                     </tbody>
                 </table>

--- a/src/pages/userStats/UserStats.js
+++ b/src/pages/userStats/UserStats.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react"
 import Table from 'react-bootstrap/Table'
-
+import mustBeAuthenticated from "../../redux/hoc/mustBeAuthenticated";
 
 // importing the ability to retrieve and use the Auth Header for API calls
 import {generateAuthHeader} from "../../utils/authHelper"
@@ -50,8 +50,7 @@ class UserStats extends Component {
         return (
             <div className="userStats">
 
-                {/* <Header isAuthenticated={this.props.isAuthenticated} /> */}
-                <Header />
+                <Header isAuthenticated={this.props.isAuthenticated} />
 
                 <h3 className="text-center" >{this.state.userStats.email}'s Statistics</h3>
                 
@@ -81,5 +80,4 @@ class UserStats extends Component {
 
 }
 
-// export default mustBeAuthenticated(Users)
-export default UserStats
+export default mustBeAuthenticated(UserStats)

--- a/src/pages/userStats/UserStats.js
+++ b/src/pages/userStats/UserStats.js
@@ -1,0 +1,84 @@
+import React, { Component } from "react"
+// import mustBeAuthenticated from "../../redux/hoc/mustBeAuthenticated";
+
+// importing the ability to retrieve and use the Auth Header for API calls
+import {generateAuthHeader} from "../../utils/authHelper"
+
+// importing components needed for the header 
+import Header from "../../components/header/Header"
+
+class UserStats extends Component {
+
+    state = {
+        userStats: []
+    }
+
+    componentDidMount() {
+
+        //get the student's id from the URL to make the API call
+        const email = this.props.match.params.email;
+
+        // Run the getUserStats method using the email obtained above
+        this.getUserStats(email)
+    }
+
+    getUserStats= (email) => {
+
+        // get the API URL from the environment variable (.env)
+        const apiURL = process.env.REACT_APP_API_URL
+
+        fetch(`${apiURL}/api/stats/${email}`, {
+            // auth header for using the currently logged in user's token for the API call
+            headers: {...generateAuthHeader()}
+        })
+            .then((results) => results.json())
+            .then((data) =>{
+                this.setState(
+                    {
+                        userStats: data
+                    }
+                )
+            })
+            .catch((error) => {
+                console.log(error)
+            })
+
+    }
+
+    render() {
+        return (
+            <div className="userStats">
+
+                {/* <Header isAuthenticated={this.props.isAuthenticated} /> */}
+                <Header />
+
+                <h3 className="text-center" >{this.state.userStats.email}'s Statistics</h3>
+                
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Number of questions answered</th>
+                            <th>Correct Answers</th>
+                            <th>Worng Answers</th>
+                            <th>Win Percentage</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>{this.state.userStats.questionsAttempted}</td>
+                            <td>{this.state.userStats.correctAnswers}</td>
+                            <td>{this.state.userStats.wrongAnswers}</td>
+                            <td></td>
+                        </tr>
+                    </tbody>
+                </table>
+                
+
+            </div>
+        )
+    }
+
+}
+
+// export default mustBeAuthenticated(Users)
+export default UserStats

--- a/src/pages/userStats/UserStats.js
+++ b/src/pages/userStats/UserStats.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react"
-// import mustBeAuthenticated from "../../redux/hoc/mustBeAuthenticated";
+import Table from 'react-bootstrap/Table'
+
 
 // importing the ability to retrieve and use the Auth Header for API calls
 import {generateAuthHeader} from "../../utils/authHelper"
@@ -54,7 +55,7 @@ class UserStats extends Component {
 
                 <h3 className="text-center" >{this.state.userStats.email}'s Statistics</h3>
                 
-                <table>
+                <Table>
                     <thead>
                         <tr>
                             <th>Number of questions answered</th>
@@ -71,7 +72,7 @@ class UserStats extends Component {
                             <td>{this.state.userStats.winRatio}</td>
                         </tr>
                     </tbody>
-                </table>
+                </Table>
                 
 
             </div>

--- a/src/pages/users/Users.js
+++ b/src/pages/users/Users.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react"
+import Table from 'react-bootstrap/Table'
 // import mustBeAuthenticated from "../../redux/hoc/mustBeAuthenticated";
 
 // importing the ability to retrieve and use the Auth Header for API calls
@@ -50,7 +51,7 @@ class Users extends Component {
                 <Header />
 
                 <h3 className="text-center" >Registered Users</h3>
-                <table>
+                <Table>
                     <thead>
                         <tr>
                             <th>First Name</th>
@@ -71,7 +72,7 @@ class Users extends Component {
                             })
                         }
                     </tbody>
-                </table>
+                </Table>
 
             </div>
         )

--- a/src/pages/users/Users.js
+++ b/src/pages/users/Users.js
@@ -15,7 +15,6 @@ class Users extends Component {
     }
 
     componentDidMount() {
-        console.log("this just ran")
         this.getUsers()
     }
 
@@ -30,7 +29,6 @@ class Users extends Component {
         })
             .then((results) => results.json())
             .then((data) =>{
-                console.log(data)
                 this.setState(
                     {
                         users: data

--- a/src/pages/users/Users.js
+++ b/src/pages/users/Users.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react"
 import Table from 'react-bootstrap/Table'
-// import mustBeAuthenticated from "../../redux/hoc/mustBeAuthenticated";
+import mustBeAuthenticated from "../../redux/hoc/mustBeAuthenticated";
 
 // importing the ability to retrieve and use the Auth Header for API calls
 import {generateAuthHeader} from "../../utils/authHelper"
@@ -47,8 +47,7 @@ class Users extends Component {
         return (
             <div className="Users">
 
-                {/* <Header isAuthenticated={this.props.isAuthenticated} /> */}
-                <Header />
+                <Header isAuthenticated={this.props.isAuthenticated} />
 
                 <h3 className="text-center" >Registered Users</h3>
                 <Table>
@@ -80,5 +79,4 @@ class Users extends Component {
 
 }
 
-// export default mustBeAuthenticated(Users)
-export default Users
+export default mustBeAuthenticated(Users)


### PR DESCRIPTION
- Created user stats paged based on the email in the parameter
- Created a nav item to link to the stats page, passing the logged in user as the email parameter
- Imported bootstrap Table to be used on Users and User Stats pages (less ugly)
- Updated Users and User Stats page to use authenticated header (API requires authentication)
- Removed User Stats link on the unauthenticated header (was initially for testing)
- Cleaned up unnecessary console.log entries on Users page